### PR TITLE
add Swagger documentation for client management endpoints

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,6 +68,16 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
+			<groupId>org.springdoc</groupId>
+			<artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+			<version>2.3.0</version>
+		</dependency>
+		<dependency>
+			<groupId>jakarta.validation</groupId>
+			<artifactId>jakarta.validation-api</artifactId>
+			<version>3.0.2</version>
+		</dependency>
+		<dependency>
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-starter-openfeign</artifactId>
 		</dependency>

--- a/src/main/java/com/mipagina/category_service/config/SwaggerConfig.java
+++ b/src/main/java/com/mipagina/category_service/config/SwaggerConfig.java
@@ -1,0 +1,19 @@
+package com.mipagina.category_service.config;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+
+    @Bean
+    public OpenAPI customOpenAPI() {
+        return new OpenAPI()
+                .info(new Info()
+                        .title("Category Service API")
+                        .version("1.0")
+                        .description("API for managing categories, including creation, retrieval, update, and deletion."));
+    }
+}

--- a/src/main/java/com/mipagina/category_service/controller/CategoryController.java
+++ b/src/main/java/com/mipagina/category_service/controller/CategoryController.java
@@ -3,6 +3,10 @@ package com.mipagina.category_service.controller;
 import com.mipagina.category_service.dto.CategoryDTO;
 import com.mipagina.category_service.model.Category;
 import com.mipagina.category_service.service.ICategoryService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.*;
 
@@ -16,37 +20,74 @@ public class CategoryController {
     @Autowired
     private ICategoryService categoryService;
 
+    @Operation(summary = "Create a new category", description = "Adds a new category to the system.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "201", description = "Category created successfully"),
+            @ApiResponse(responseCode = "400", description = "Invalid category data")
+    })
     @PostMapping("/create")
-    public void createCategory(@RequestBody Category category ){
+    public void createCategory(
+            @Parameter(description = "Category object to be created", required = true)
+            @RequestBody Category category) {
         categoryService.saveCategory(category);
     }
 
+    @Operation(summary = "Retrieve all categories", description = "Returns a list of all categories in the system.")
+    @ApiResponse(responseCode = "200", description = "Categories retrieved successfully")
     @GetMapping("/bring_all")
-    public List<Category> bringAllCategory(){
+    public List<Category> bringAllCategory() {
         return categoryService.findAllCategory();
     }
 
+    @Operation(summary = "Retrieve a category by ID", description = "Returns a category based on the provided category ID.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Category found successfully"),
+            @ApiResponse(responseCode = "404", description = "Category not found")
+    })
     @GetMapping("/bring_category/{id_category}")
-    public Category getCategoryById(@PathVariable Long id_category){
+    public Category getCategoryById(
+            @Parameter(description = "ID of the category to retrieve", example = "1", required = true)
+            @PathVariable Long id_category) {
         return categoryService.getCategory(id_category);
     }
 
+    @Operation(summary = "Edit category details", description = "Updates the information of an existing category.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Category edited successfully"),
+            @ApiResponse(responseCode = "404", description = "Category not found")
+    })
     @PutMapping("/edit/{id_category}")
-    public String editCategory(@PathVariable Long id_category,
-                                 @RequestBody Category category){
-        categoryService.editCategory(id_category,category);
-        return "Category edited Successfully";
+    public String editCategory(
+            @Parameter(description = "ID of the category to edit", example = "1", required = true)
+            @PathVariable Long id_category,
+            @Parameter(description = "Updated category data", required = true)
+            @RequestBody Category category) {
+        categoryService.editCategory(id_category, category);
+        return "Category edited successfully";
     }
 
+    @Operation(summary = "Delete a category", description = "Removes a category from the system using the provided ID.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Category deleted successfully"),
+            @ApiResponse(responseCode = "404", description = "Category not found")
+    })
     @DeleteMapping("/delete/{id_category}")
-    public String deleteCategory(@PathVariable Long id_category){
+    public String deleteCategory(
+            @Parameter(description = "ID of the category to delete", example = "1", required = true)
+            @PathVariable Long id_category) {
         categoryService.deleteCategory(id_category);
         return "Category deleted successfully";
     }
 
+    @Operation(summary = "Retrieve category with products", description = "Returns a category along with its associated products.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Category and products retrieved successfully"),
+            @ApiResponse(responseCode = "404", description = "Category not found")
+    })
     @GetMapping("/products/{id_category}")
-    public CategoryDTO getProductsAndCategory (@PathVariable Long id_category){
+    public CategoryDTO getProductsAndCategory(
+            @Parameter(description = "ID of the category", example = "1", required = true)
+            @PathVariable Long id_category) {
         return categoryService.getProductsAndCategory(id_category);
     }
-
 }

--- a/src/main/java/com/mipagina/category_service/model/Category.java
+++ b/src/main/java/com/mipagina/category_service/model/Category.java
@@ -1,22 +1,23 @@
 package com.mipagina.category_service.model;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
 
 @Entity
 public class Category {
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Schema(description = "Unique identifier of the category", example = "1")
     private Long id_category;
+
+    @Schema(description = "Name of the category", example = "Electronics", required = true)
     private String name;
 
-    public Long getId_category() {
+public Long getId_category() {
         return id_category;
     }
 


### PR DESCRIPTION
This update enhances the API documentation by integrating Swagger annotations into the ClientController. The improvements ensure better clarity and usability for developers interacting with the client management endpoints.

Changes:
Added @Operation annotations to all endpoints to provide clear descriptions.
Documented query parameters using @Parameter to specify required fields and examples.
Included detailed @ApiResponses for various response scenarios (200, 201, 400, 404).
Improved overall API documentation to facilitate easier integration and usage.

Reviewer: @JuanGuevara90